### PR TITLE
Fix exception when logging an object containing a function

### DIFF
--- a/src/main/baseConnector.js
+++ b/src/main/baseConnector.js
@@ -29,25 +29,30 @@ function getErrorType(e) {
  * @param {object} payload
  */
 function sanitizePayload(payload) {
-    if (payload && typeof(payload) === 'object') {
-        const isArray = Array.isArray(payload);
-        const sanitizedPayload = isArray ? [] : {};
+    if (payload) {
+        if (typeof (payload) === 'function') {
+            // remove functions from the payload, because they cannot be copied by the postMessage function
+            return
+        } else if (typeof (payload) === 'object') {
+            const isArray = Array.isArray(payload);
+            const sanitizedPayload = isArray ? [] : {};
 
-        if (isArray) {
-            payload.forEach(element => {
-                sanitizedPayload.push(sanitizePayload(element));
-            });
-        } else {
-            for (const property in payload) {
-                if (property !== 'phoneNumber' &&
-                    property !== 'number' &&
-                    property !== 'name' && 
-                    property !== 'callAttributes') {
-                    sanitizedPayload[property] = sanitizePayload(payload[property]);
+            if (isArray) {
+                payload.forEach(element => {
+                    sanitizedPayload.push(sanitizePayload(element));
+                });
+            } else {
+                for (const property in payload) {
+                    if (property !== 'phoneNumber' &&
+                        property !== 'number' &&
+                        property !== 'name' &&
+                        property !== 'callAttributes') {
+                        sanitizedPayload[property] = sanitizePayload(payload[property]);
+                    }
                 }
             }
+            return sanitizedPayload;
         }
-        return sanitizedPayload;
     }
     return payload;
 }

--- a/src/main/baseConnector.js
+++ b/src/main/baseConnector.js
@@ -32,7 +32,7 @@ function sanitizePayload(payload) {
     if (payload) {
         if (typeof (payload) === 'function') {
             // remove functions from the payload, because they cannot be copied by the postMessage function
-            return
+            return;
         } else if (typeof (payload) === 'object') {
             const isArray = Array.isArray(payload);
             const sanitizedPayload = isArray ? [] : {};

--- a/src/test/baseConnector.test.js
+++ b/src/test/baseConnector.test.js
@@ -2326,6 +2326,28 @@ describe('SCVConnectorBase tests', () => {
                     isError
                 });
             });
+            it('the event contains a function', async () => {
+                const eventType = 'anyEvent';
+                const payload = {
+                    firstname: 'Jon',
+                    key: (param) => {
+                        return param
+                    }
+                };
+                const expectedPayload = {
+                    firstname: 'Jon'
+                };
+                const isError = true;
+                publishLog({ eventType, payload, isError });
+                expect(channelPort.postMessage).toHaveBeenCalledWith({
+                    type: constants.MESSAGE_TYPE.LOG,
+                    payload: {
+                        eventType,
+                        payload: expectedPayload,
+                        isError
+                    }
+                });
+            })
         });
     });
 


### PR DESCRIPTION
### Why
Logging a message to the Partner Telephony System sends a post message to the partner frame. In order to send the payload as via postMessage it has to be clonable. 
Our Partner Connector is loaded as a Visualforce page with an Apex Controller. The VFRemoting code extends the Date object as followed: 
```
Date.prototype.getElapsed = function(d) {
    return Math.abs((d || new Date).getTime() - this.getTime())
};
```
This results in an exception for all events containing the  `callStateTimestamp` on the `CallInfo`, since it's a `Date`.

E.g.: the exception when dialing out with `softphone false`: 
> SCV dispatched error CAN_NOT_START_THE_CALL for eventType DIAL Failed to execute 'postMessage' on 'MessagePort': function(d){return Math.abs((d||new Date).getTime()-this.getTime())} could not be cloned.


This issue is in the code since the commit [updated scv-connector-base from v53](https://github.com/salesforce/scv-connector-base/commit/bec7115f0147ea2375de785a441362e53d07d30d) 

### How

The function `sanitizePayload` ensures that for objects and arrays are clonable and can be send via postmessage. Extended this function to remove functions from the payload. 

### Further Info

* A possble workaround for us would be to never send the `callStateTimestamp` but the the call time on the UI resets after each refresh.

* Since the [demo connector](https://github.com/salesforce/demo-scv-connector) is loaded via localhost and not as a Visualforce page, it does not have this issue.


For further Questions answer to this PR or contact me over Bucher + Suter.
