### PR TITLE
extend the `downloadLogs` vendorConnector function to take the logs as parameter

### DIFF
--- a/src/main/baseConnector.js
+++ b/src/main/baseConnector.js
@@ -12,7 +12,7 @@ import { Validator, GenericResult, InitResult, CallResult, HangupResult, HoldTog
     ParticipantResult, RecordingToggleResult, AgentConfigResult, ActiveCallsResult, SignedRecordingUrlResult, LogoutResult,
     VendorConnector, Contact, AudioStats, SuperviseCallResult, SupervisorHangupResult, AgentStatusInfo} from './types';
 import { enableMos, getMOS, initAudioStats, updateAudioStats } from './mosUtil';
-import { log } from './logger';
+import { getLogs, log } from './logger';
 
 let channelPort;
 let vendorConnector;
@@ -478,7 +478,7 @@ async function channelMessageHandler(message) {
             }
         break;
         case constants.MESSAGE_TYPE.DOWNLOAD_VENDOR_LOGS:
-            vendorConnector.downloadLogs();
+            vendorConnector.downloadLogs(getLogs());
         break;
         case constants.MESSAGE_TYPE.LOG: {
                 const { logLevel, logMessage, payload } = message.data;

--- a/src/main/types.js
+++ b/src/main/types.js
@@ -853,7 +853,7 @@ export class VendorConnector {
     /**
      * Triggers a browser download for Vendor Logs
      */
-    downloadLogs() {
+    downloadLogs(logs) {
         downloadLogs();
     }
 

--- a/src/test/baseConnector.test.js
+++ b/src/test/baseConnector.test.js
@@ -11,7 +11,7 @@ import { ActiveCallsResult, InitResult, CallResult, HoldToggleResult, GenericRes
     AgentConfigResult, Phone, HangupResult, SignedRecordingUrlResult, LogoutResult, AudioStats, StatsInfo, AudioStatsElement, SuperviseCallResult, SupervisorHangupResult } from '../main/index';
 import baseConstants from '../main/constants';
 
-import { log } from '../main/logger';
+import { log, getLogs } from '../main/logger';
 jest.mock('../main/logger');
 
 const constants = {
@@ -1504,6 +1504,17 @@ describe('SCVConnectorBase tests', () => {
             it('Should invoke downloadLogs() when DOWNLOAD_VENDOR_LOGS is published', () => {
                 fireMessage(constants.MESSAGE_TYPE.DOWNLOAD_VENDOR_LOGS);
                 expect(adapter.downloadLogs).toBeCalledTimes(1);
+            });
+            it('Should pass the saved logmessages to downloadLogs() when DOWNLOAD_VENDOR_LOGS is published', () => {
+                getLogs.mockImplementationOnce(() => [
+                    '"2022-02-10T20:10:30.503Z|INFO|SYSTEM|{"eventType":"SETUP_CONNECTOR","payload":{}'
+                    ]
+                );
+                fireMessage(constants.MESSAGE_TYPE.DOWNLOAD_VENDOR_LOGS);
+                expect(adapter.downloadLogs).toBeCalledTimes(1);
+                expect(adapter.downloadLogs).toBeCalledWith([
+                    '"2022-02-10T20:10:30.503Z|INFO|SYSTEM|{"eventType":"SETUP_CONNECTOR","payload":{}'
+                ]);
             });
         });
 

--- a/ts-declaration/logger.d.ts
+++ b/ts-declaration/logger.d.ts
@@ -9,7 +9,7 @@ export function log(logMessage: object, logLevel: string, logSource?: string): v
  *
  * @returns a deep copy of the logs array
  */
-export function getLogs(): any;
+export function getLogs(): string[];
 /**
  * Download the logs as a file
  */

--- a/ts-declaration/types.d.ts
+++ b/ts-declaration/types.d.ts
@@ -707,7 +707,7 @@ export class VendorConnector {
     /**
      * Triggers a browser download for Vendor Logs
      */
-    downloadLogs(): void;
+    downloadLogs(logs: string[]): void;
     /**
      * Sends the logs with a logLevel and payload to the vendor connector.
      * Does a no-op, if not implemented.


### PR DESCRIPTION
Currently, the `downloadLogs` function has no parameters and the VendorConnector cannot get the actual logs. 
This PR adds the list of the logs as a parameter to the `downloadLogs` function.
Now the VendorConnector can use those logs and e.g. send them together with their own logs to a server.